### PR TITLE
Link to the Chatterino homies discord in the About tab

### DIFF
--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -21,7 +21,7 @@
 #define LINK_CHATTERINO_WIKI "https://wiki.chatterino.com"
 #define LINK_DONATE "https://streamelements.com/fourtf/tip"
 #define LINK_CHATTERINO_FEATURES "https://chatterino.com/#features"
-#define LINK_CHATTERINO_DISCORD "https://discord.gg/7Y5AYhAK4z"
+#define LINK_CHATTERINO_DISCORD "https://discord.gg/ZPxUUzDjbM"
 
 namespace chatterino {
 
@@ -67,7 +67,7 @@ AboutPage::AboutPage()
             // clang-format off
             l.emplace<QLabel>("Chatterino Wiki can be found <a href=\"" LINK_CHATTERINO_WIKI "\">here</a>")->setOpenExternalLinks(true);
             l.emplace<QLabel>("All about Chatterino's <a href=\"" LINK_CHATTERINO_FEATURES "\">features</a>")->setOpenExternalLinks(true);
-            l.emplace<QLabel>("Join the official Chatterino <a href=\"" LINK_CHATTERINO_DISCORD "\">Discord</a>")->setOpenExternalLinks(true);
+            l.emplace<QLabel>("Join the official Chatterino Homies <a href=\"" LINK_CHATTERINO_DISCORD "\">Discord</a>")->setOpenExternalLinks(true);
             // clang-format on
         }
 


### PR DESCRIPTION
Changed and marked the discord link to direct Chatterino homies users, to the Chatterino homies discord, as we are unable to help them with Chatterino homies problems, in the Chatterino discord. :+1: